### PR TITLE
Add systemd_tmpfiles role

### DIFF
--- a/roles/systemd_tmpfiles/LICENSE
+++ b/roles/systemd_tmpfiles/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Crown Copyright (Companies House)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/roles/systemd_tmpfiles/README.md
+++ b/roles/systemd_tmpfiles/README.md
@@ -1,0 +1,50 @@
+# Ansible Role: systemd-tmpfiles 
+
+An [Ansible Galaxy](https://galaxy.ansible.com/) role for configuring `systemd-tmpfiles(8)` cleanup of files and directories in `/tmp`.
+
+## Table of contents
+
+* [Configuration][1]
+* [Example Requirements File][2]
+* [Example Playbook][3]
+* [License][4]
+
+[1]: #configuration
+[2]: #example-requirements-file
+[3]: #example-playbook
+[4]: #license
+
+## Configuration
+
+All configuration is managed through group/host variables. The following variables can be defined to override the default values when necessary:
+
+| Name                        | Default             | Description                                                                           |
+|-----------------------------|---------------------|---------------------------------------------------------------------------------------|
+| `systemd_tmpfiles_age`      | `1d`                | Used to decide what files to delete from `/tmp` when cleaning. If a file or directory is older than the current time minus the age value, it is deleted. |
+| `systemd_tmpfiles_filename` | `tmp.conf`          | The name of the configuration file to create in `/etc/tmpfiles.d`. This should be the same name as the configuration files installed by vendor packages in `/usr/lib/tmpfiles.d` or `/run/tmpfiles.d` containing an entry for the `/tmp` directory to be overridden. |
+| `systemd_tmpfiles_type`     | `v`                 | The type consists of a single letter and optionally one or more modifier characters: a plus sign ("+"), exclamation mark ("!"), minus sign ("-"), equals sign ("="), tilde character ("~") and/or caret ("^"). See `tmpfiles.d(5)` for more information. |
+
+## Example Requirements File
+
+```yml
+---
+
+collections:
+  - name: companieshouse.general
+    version: "1.0.0"
+```
+
+## Example Playbook
+
+```yml
+---
+
+- name: Provision systemd-tmpfiles age
+  hosts: all
+  roles:
+    - role: companieshouse.general.systemd_tmpfiles
+```
+
+## License
+
+This project is subject to the terms of the [MIT License](LICENSE).

--- a/roles/systemd_tmpfiles/defaults/main.yml
+++ b/roles/systemd_tmpfiles/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+systemd_tmpfiles_age: 1d
+systemd_tmpfiles_filename: tmp.conf
+systemd_tmpfiles_type: v

--- a/roles/systemd_tmpfiles/meta/main.yml
+++ b/roles/systemd_tmpfiles/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  role_name: systemd_tmpfiles
+  author: Companies House
+  description: Provision systemd-tmpfiles age and type configuration for /tmp directory
+  license: MIT
+  min_ansible_version: 2.9.10
+  galaxy_tags:
+    - systemd
+    - tmpfiles
+  standalone: false

--- a/roles/systemd_tmpfiles/meta/main.yml
+++ b/roles/systemd_tmpfiles/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   role_name: systemd_tmpfiles
   author: Companies House
-  description: Provision systemd-tmpfiles age and type configuration for /tmp directory
+  description: Provision systemd-tmpfiles configuration for /tmp directory
   license: MIT
   min_ansible_version: 2.9.10
   galaxy_tags:

--- a/roles/systemd_tmpfiles/tasks/main.yml
+++ b/roles/systemd_tmpfiles/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Assert age is correctly formatted
+  ansible.builtin.assert:
+    that: systemd_tmpfiles_age is regex("^\d+(s|m|min|h|d|w|ms|us|seconds|minutes|hours|days|weeks|milliseconds|microseconds)$")
+    fail_msg: >
+      The age value should be an integer followed by one of the suffixes for the respective time units: s, m or min,
+      h, d, w, ms, and us, or one of the full unit names: seconds, minutes, hours, days, weeks, milliseconds, and
+      microseconds. See tmpfiles.d(5) for more information.
+
+- name: Assert type is correctly formatted
+  ansible.builtin.assert:
+    that: systemd_tmpfiles_type is regex("^[fwdDevqQpLcbCxXrRzZtThHaA][+!-=~^]*$")
+    fail_msg: >
+      The type value should be a single letter and optionally one or more modifier characters: a plus sign ("+"),
+      exclamation mark ("!"), minus sign ("-"), equals sign ("="), tilde character ("~") and/or caret ("^"). See
+      tmpfiles.d(5) for more information.
+
+- name: Create configuration file
+  ansible.builtin.template:
+    src: tmp.conf.j2
+    dest: "/etc/tmpfiles.d/{{ systemd_tmpfiles_filename }}"
+    owner: root
+    group: root
+    mode: '0644'

--- a/roles/systemd_tmpfiles/templates/tmp.conf.j2
+++ b/roles/systemd_tmpfiles/templates/tmp.conf.j2
@@ -1,0 +1,1 @@
+{{ systemd_tmpfiles_type }} /tmp 1777 root root {{ systemd_tmpfiles_age }}


### PR DESCRIPTION
This change introduces a new `systemd_tmpfiles` role for overriding the configuration of the `/tmp` directory. Several systems ([fil-tuxedo-stack](https://github.com/companieshouse/fil-tuxedo-stack), [dps-tuxedo-stack](https://github.com/companieshouse/dps-tuxedo-stack), [ais-tuxedo-stack](https://github.com/companieshouse/ais-tuxedo-stack)) make frequent use of temporary files—exceeding gigabytes of data in some cases—which can quickly fill up the available space with the default configuration for `/tmp`. This role allows the `age` and `type` settings to modified, such that temporary files can be cleaned up sooner by reducing the `age` value.